### PR TITLE
51 feat: Add dev menu with delete scores option

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import './App.css';
 // Components
 import Header from './components/Header';
 import Footer from './components/Footer';
+import DevMenu from './components/DevMenu';
 
 // Pages
 import Quiz from './pages/Quiz';
@@ -29,6 +30,7 @@ function App() {
             <Route path="/auth" element={<Auth />} />
           </Routes>
         </div>
+        <DevMenu />
         <Footer /> {/* Global footer */}
       </div>
     </Router>

--- a/src/components/DevMenu.css
+++ b/src/components/DevMenu.css
@@ -1,0 +1,58 @@
+/* src/components/DevMenu.css */
+
+.dev-toggle {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    background-color: #4e54c8;
+    color: white;
+    padding: 0.5rem 1rem;
+    font-weight: bold;
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    z-index: 999;
+    transition: background 0.2s ease-in-out;
+}
+
+.dev-toggle:hover {
+    background-color: #3b3fbb;
+}
+
+.dev-panel {
+    position: fixed;
+    bottom: 3.5rem;
+    right: 1rem;
+    background-color: white;
+    color: black;
+    padding: 1rem;
+    border-radius: 1rem;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    z-index: 998;
+    width: 220px;
+}
+
+.dev-panel h4 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    font-size: 1rem;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 0.5rem;
+}
+
+.dev-panel button {
+    display: block;
+    width: 100%;
+    margin: 0.25rem 0;
+    padding: 0.5rem;
+    background-color: #eee;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.dev-panel button:hover {
+    background-color: #ddd;
+}

--- a/src/components/DevMenu.jsx
+++ b/src/components/DevMenu.jsx
@@ -1,0 +1,25 @@
+// src/components/DevMenu.jsx
+import React, { useState } from 'react';
+import './DevMenu.css';
+
+const DevMenu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="dev-menu">
+      <button className="dev-toggle" onClick={() => setIsOpen(!isOpen)}>
+        DEV
+      </button>
+      {isOpen && (
+        <div className="dev-panel">
+          <h4>Dev Menu</h4>
+          <button onClick={() => alert('Reset quiz')}>Reset Quiz</button>
+          <button onClick={() => alert('Show token')}>Show Token</button>
+          <button onClick={() => alert('Clear user')}>Clear User</button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DevMenu;

--- a/src/components/DevMenu.jsx
+++ b/src/components/DevMenu.jsx
@@ -1,5 +1,6 @@
 // src/components/DevMenu.jsx
 import React, { useState } from 'react';
+import { deleteAllScores } from '../services/firestoreService';
 import './DevMenu.css';
 
 const DevMenu = () => {
@@ -13,9 +14,7 @@ const DevMenu = () => {
       {isOpen && (
         <div className="dev-panel">
           <h4>Dev Menu</h4>
-          <button onClick={() => alert('Reset quiz')}>Reset Quiz</button>
-          <button onClick={() => alert('Show token')}>Show Token</button>
-          <button onClick={() => alert('Clear user')}>Clear User</button>
+          <button onClick={deleteAllScores}>Reset All Scores</button>
         </div>
       )}
     </div>

--- a/src/services/firestoreService.js
+++ b/src/services/firestoreService.js
@@ -29,6 +29,7 @@ import {
   doc,
   setDoc,
   getDoc,
+  deleteDoc,
 } from 'firebase/firestore';
 
 /**
@@ -97,5 +98,25 @@ export const getTopScores = async () => {
   } catch (error) {
     console.error('❌ Error fetching top scores:', error);
     return [];
+  }
+};
+
+/**
+ * Resets (i.e. deletes) all quiz scores in Firebase from DevMenu.
+ */
+export const deleteAllScores = async () => {
+  try {
+    const scoresRef = collection(db, 'scores');
+    const snapshot = await getDocs(scoresRef);
+
+    const deletePromises = snapshot.docs.map((docSnap) =>
+      deleteDoc(doc(db, 'scores', docSnap.id))
+    );
+
+    await Promise.all(deletePromises);
+    alert('✅ All scores have been reset.');
+  } catch (error) {
+    console.error('❌ Error deleting scores:', error);
+    alert('❌ Failed to reset scores. See console for details.');
   }
 };


### PR DESCRIPTION
**This PR introduces a new DevMenu accessible in the bottom-right corner of the app. It includes a developer utility to delete all quiz scores from Firestore.**

Changes:
- Added deleteAllScores function to `firestoreService.js`
- Connected DevMenu to call the function and show confirmation
- UI and styles updated for DevMenu

Note: The "type scores" collection was removed manually from Firestore as it was unused.