### PR TITLE
feat: add responsive design to quiz components

### DIFF
--- a/src/components/QuestionCard.css
+++ b/src/components/QuestionCard.css
@@ -1,13 +1,14 @@
 /* 
- * Simpler styles for Question Card component with fixed spacing
+ * Styles for Question Card component with responsive design
  */
 
+/* Main container for the question card */
 .question-card {
-  max-width: 600px;
+  max-width: min(600px, 100% - 1rem); /* Responsive maximum width */
   width: 100%;
   margin: 0 auto;
   background-color: rgba(255, 255, 255, 0.1);
-  border-radius: 1.5rem;
+  border-radius: clamp(1rem, 2.5vw, 1.5rem); /* Responsive border radius */
   backdrop-filter: blur(8px);
   box-shadow:
     0 4px 6px rgba(0, 0, 0, 0.3),
@@ -17,32 +18,37 @@
   position: relative;
 }
 
+/* Container for question and answers content */
 .question-content {
-  padding: 1.5rem 1.25rem;
+  padding: clamp(1rem, 3vw, 1.5rem); /* Responsive padding */
 }
 
+/* Styling for the quiz question text */
 .quiz-question {
-  font-size: 1.5rem;
+  font-size: clamp(1.1rem, 3.5vw, 1.5rem); /* Responsive font size */
   font-weight: 700;
-  margin-bottom: 2rem;
+  margin-bottom: clamp(1rem, 4vw, 2rem); /* Responsive margin */
   color: white;
   text-align: center;
   line-height: 1.4;
   padding: 0 0.5rem;
   word-wrap: break-word;
+  hyphens: auto; /* Better text breaking on mobile */
 }
 
+/* Container for all answer options */
 .answers {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: clamp(0.5rem, 2vw, 1rem); /* Responsive gap between answers */
   width: 100%;
 }
 
+/* Individual answer button styling */
 .answer-button {
   width: 100%;
-  padding: 1rem 1.25rem;
-  font-size: 1rem;
+  padding: clamp(0.625rem, 2.5vw, 1rem) clamp(0.75rem, 3vw, 1.25rem); /* Responsive padding */
+  font-size: clamp(0.8rem, 2.5vw, 1rem); /* Responsive font size */
   background-color: rgba(255, 255, 255, 0.9);
   color: #4f46e5;
   border: none;
@@ -57,14 +63,18 @@
   align-items: center;
   text-align: left;
   overflow-wrap: break-word;
+  word-wrap: break-word; /* Legacy support */
+  hyphens: auto; /* Better text breaking */
+  min-height: 44px; /* Touch-friendly minimum height */
 }
 
+/* Letter circle for each answer option (A, B, C, D) */
 .answer-letter {
-  font-size: 1.2rem;
+  font-size: clamp(0.9rem, 2.5vw, 1.2rem); /* Responsive font size */
   font-weight: 700;
-  margin-right: 0.75rem;
-  width: 28px;
-  height: 28px;
+  margin-right: clamp(0.5rem, 2vw, 0.75rem); /* Responsive margin */
+  width: clamp(24px, 6vw, 28px); /* Responsive width */
+  height: clamp(24px, 6vw, 28px); /* Responsive height */
   border-radius: 50%;
   background-color: #4f46e5;
   color: white;
@@ -74,10 +84,13 @@
   flex-shrink: 0;
 }
 
+/* Text content of each answer */
 .answer-text {
   flex-grow: 1;
+  line-height: 1.3;
 }
 
+/* Hover effect for answer buttons */
 .answer-button:hover:not(:disabled) {
   background-color: #4e54c8;
   color: white;
@@ -87,15 +100,18 @@
     0 2px 4px rgba(0, 0, 0, 0.4); /* Increased shadow on hover */
 }
 
+/* Hover effect for the letter circle */
 .answer-button:hover:not(:disabled) .answer-letter {
   background-color: white;
   color: #4e54c8;
 }
 
+/* Disabled state for answer buttons */
 .answer-button:disabled {
   cursor: default;
 }
 
+/* Styling for correct answer button */
 .answer-button.correct {
   background-color: #10b981;
   color: white;
@@ -104,38 +120,46 @@
   box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.5);
 }
 
+/* Letter circle styling for correct answer */
 .answer-button.correct .answer-letter {
   background-color: white;
   color: #10b981;
 }
 
+/* Styling for incorrect answer button */
 .answer-button.incorrect {
   background-color: #ef4444;
   color: white;
 }
 
+/* Letter circle styling for incorrect answer */
 .answer-button.incorrect .answer-letter {
   background-color: white;
   color: #ef4444;
 }
 
+/* Styling for faded answer buttons (when feedback is shown) */
 .answer-button.faded {
   opacity: 0.6;
   transform: scale(0.98);
 }
 
-/* Fixed spacing that stays consistent whether feedback is shown or not */
+/* Reserved space for feedback area with responsive height */
 .feedback-spacing {
-  height: 150px; /* Reserve this much vertical space regardless */
+  height: clamp(
+    120px,
+    25vw,
+    150px
+  ); /* Responsive height that stays consistent */
 }
 
-/* Feedback container is positioned absolutely */
+/* Container for feedback messages and next button */
 .feedback-container {
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  height: 150px;
+  height: clamp(120px, 25vw, 150px); /* Matches feedback-spacing height */
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -144,6 +168,7 @@
   animation: fadeIn 0.3s ease-out;
 }
 
+/* Fade-in animation for feedback container */
 @keyframes fadeIn {
   0% {
     opacity: 0;
@@ -153,28 +178,32 @@
   }
 }
 
+/* Styling for feedback text (correct/incorrect message) */
 .feedback-text {
   text-align: center;
-  font-size: 1.3rem;
+  font-size: clamp(1rem, 3vw, 1.3rem); /* Responsive font size */
   font-weight: 700;
-  padding: 0.6rem 1.5rem;
+  padding: clamp(0.4rem, 1.5vw, 0.6rem) clamp(1rem, 3vw, 1.5rem); /* Responsive padding */
   border-radius: 9999px;
-  margin-bottom: 1.25rem;
+  margin-bottom: clamp(0.75rem, 3vw, 1.25rem); /* Responsive margin */
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.3),
     0 4px 6px rgba(0, 0, 0, 0.2); /* Sharper, more defined shadow */
 }
 
+/* Styling for correct answer feedback */
 .correct-feedback {
   color: white;
   background-color: #10b981;
 }
 
+/* Styling for incorrect answer feedback */
 .incorrect-feedback {
   color: white;
   background-color: #ef4444;
 }
 
+/* Next question button styling */
 .next-question-btn {
   display: flex;
   align-items: center;
@@ -183,8 +212,9 @@
   color: white;
   border: none;
   border-radius: 9999px;
-  padding: 0.75rem 1.5rem 0.75rem 1.75rem; /* More padding on right for arrow */
-  font-size: 1.1rem;
+  padding: clamp(0.5rem, 2vw, 0.75rem) clamp(1rem, 3vw, 1.5rem)
+    clamp(0.5rem, 2vw, 0.75rem) clamp(1.25rem, 3.5vw, 1.75rem); /* Responsive padding with extra on right for arrow */
+  font-size: clamp(0.9rem, 2.5vw, 1.1rem); /* Responsive font size */
   font-weight: 700;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -192,10 +222,12 @@
     0 2px 4px rgba(0, 0, 0, 0.3),
     0 4px 8px rgba(0, 0, 0, 0.2),
     0 0 0 2px rgba(79, 70, 229, 0.3); /* Combined shadow and subtle outline */
-  min-width: 120px;
+  min-width: clamp(100px, 25vw, 120px); /* Responsive minimum width */
   animation: pulse 1.5s infinite;
+  min-height: 44px; /* Touch-friendly minimum height */
 }
 
+/* Pulsing animation for next button */
 @keyframes pulse {
   0% {
     box-shadow:
@@ -217,6 +249,7 @@
   }
 }
 
+/* Hover effect for next button */
 .next-question-btn:hover {
   background-color: #4338ca;
   transform: translateY(-3px);
@@ -226,13 +259,19 @@
     0 0 0 2px rgba(79, 70, 229, 0.5); /* Stronger shadow on hover */
 }
 
+/* Active state for next button */
 .next-question-btn:active {
   transform: translateY(-1px);
 }
 
+/* Arrow icon in next button */
 .arrow-icon {
-  font-size: 1.75rem; /* Much larger arrow */
-  margin-left: 0.75rem; /* More spacing */
+  font-size: clamp(
+    1.25rem,
+    3.5vw,
+    1.75rem
+  ); /* Much larger arrow with responsive sizing */
+  margin-left: clamp(0.5rem, 2vw, 0.75rem); /* Responsive margin */
   font-weight: bold; /* Bolder arrow */
   text-shadow: 0 0 10px rgba(255, 255, 255, 0.5); /* Glowing effect */
   position: relative; /* For animation */
@@ -250,6 +289,7 @@
   }
 }
 
+/* Text in next button */
 .next-text {
   margin-right: 0.25rem;
 }
@@ -257,48 +297,32 @@
 /* Mobile-specific adjustments */
 @media (max-width: 480px) {
   .question-card {
-    border-radius: 1.25rem;
-    margin: 0 0.5rem;
-    width: calc(100% - 1rem);
+    border-radius: 1rem;
+    margin: 0 0.25rem;
+    width: calc(100% - 0.5rem);
   }
 
   .question-content {
-    padding: 1.25rem 1rem;
-  }
-
-  .quiz-question {
-    font-size: 1.2rem;
-    margin-bottom: 1.5rem;
+    padding: 1rem 0.875rem;
   }
 
   .answer-button {
-    padding: 0.75rem 1rem;
-    font-size: 0.9rem;
+    min-height: 48px; /* Larger touch target on mobile */
+  }
+}
+
+/* Ultra-wide screen adjustments */
+@media (min-width: 1200px) {
+  .question-card {
+    max-width: 700px;
   }
 
-  .answer-letter {
-    font-size: 1rem;
-    min-width: 24px;
-    height: 24px;
-    margin-right: 0.5rem;
+  .quiz-question {
+    font-size: 1.75rem;
   }
 
-  .feedback-spacing {
-    height: 130px; /* Smaller on mobile */
-  }
-
-  .feedback-container {
-    height: 130px; /* Match the spacing height */
-  }
-
-  .feedback-text {
+  .answer-button {
     font-size: 1.1rem;
-    padding: 0.5rem 1.25rem;
-    margin-bottom: 1rem;
-  }
-
-  .next-question-btn {
-    padding: 0.6rem 1.25rem;
-    font-size: 1rem;
+    padding: 1.1rem 1.5rem;
   }
 }

--- a/src/components/QuizLayout.css
+++ b/src/components/QuizLayout.css
@@ -1,19 +1,22 @@
-/* ------------------------------------
-   Quiz Layout and Container
------------------------------------- */
+/* src/components/QuizLayout.css
+ * Layout-specific styling for quiz pages
+ */
+
+/* Main layout container with gradient background */
 .quiz-layout {
   min-height: 100vh;
+  min-height: 100svh; /* Small viewport height for better mobile support */
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  padding: 1rem 0.75rem 3rem; /* Increased horizontal padding */
+  padding: 0.5rem; /* Responsive padding */
   box-sizing: border-box;
   background: linear-gradient(135deg, #4e54c8, #8f94fb);
   color: white;
   position: relative; /* Creates positioning context */
   overflow-x: hidden; /* Prevent horizontal scroll */
-  width: 100%; /* Ensure full width */
+  width: 100%;
 }
 
 /* Add a subtle animated gradient background */
@@ -32,10 +35,11 @@
   z-index: 0;
 }
 
+/* Main content container for quiz elements */
 .quiz-container {
   background: transparent;
   text-align: center;
-  max-width: 650px; /* Increased width to match content */
+  max-width: min(650px, 100% - 1rem); /* Responsive maximum width */
   width: 100%;
   flex: 1;
   display: flex;
@@ -44,117 +48,34 @@
   justify-content: flex-start;
   position: relative; /* Place above the background */
   z-index: 1;
-  padding: 0 0.75rem; /* Increased horizontal padding */
+  padding: 0;
 }
 
-.quiz-page {
-  display: flex;
-  gap: 1.5rem; /* Reduced gap for mobile */
-  align-items: center; /* Changed to center align */
-  justify-content: center;
-  width: 100%;
-  flex-wrap: wrap;
-}
-
-/* ------------------------------------
-   Question Display
------------------------------------- */
-.quiz-question {
-  font-size: 1.75rem;
-  font-weight: 700;
-  margin-bottom: 2rem;
-  line-height: 1.4; /* Better readability */
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); /* Text shadow for better contrast */
-}
-
-/* ------------------------------------
-   Answers
------------------------------------- */
-.answers {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  width: 100%;
-  margin-top: 2rem;
-}
-
-.answer-button {
-  width: 100%;
-  padding: 1rem;
-  font-size: 1rem;
-  background-color: #ffffff;
-  color: #4f46e5;
-  border-radius: 9999px;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.25),
-    0 1px 2px rgba(0, 0, 0, 0.3);
-  transition: all 0.2s ease-in-out;
-  display: flex;
-  align-items: center;
-  text-align: left; /* Left align text */
-  overflow-wrap: break-word; /* Ensure long words break */
-  word-wrap: break-word; /* Legacy support */
-}
-
-.answer-button:hover {
-  background-color: #4e54c8;
-  color: white;
-  transform: scale(1.05);
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 2px 4px rgba(0, 0, 0, 0.4);
-}
-
-.answer-button:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.4);
-}
-
-/* Add some responsive design improvements */
+/* Responsive adjustments for tablet screens */
 @media (max-width: 768px) {
+  .quiz-layout {
+    padding: 0.25rem; /* Reduced padding on tablets */
+  }
+
   .quiz-container {
-    padding: 0 1rem; /* Increased padding */
-  }
-
-  .quiz-question {
-    font-size: 1.4rem; /* Smaller font on mobile */
-    padding: 0 0.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .answers {
-    gap: 0.75rem;
-  }
-
-  /* Ensure fixed height elements don't cause overflow */
-  .quiz-user {
-    margin-bottom: 1rem;
+    max-width: 100%;
   }
 }
 
-/* Smaller phones */
+/* Mobile-specific adjustments */
 @media (max-width: 480px) {
   .quiz-layout {
-    padding: 0.5rem 1rem 2rem; /* Increased horizontal padding */
+    padding: 0.125rem; /* Minimal padding on mobile */
   }
 
   .quiz-container {
-    padding: 0 0.5rem; /* Maintain some padding */
+    min-height: 0; /* Allow container to shrink on very small screens */
   }
+}
 
-  .quiz-question {
-    font-size: 1.2rem; /* Further reduced font size */
-  }
-
-  .answer-button {
-    padding: 0.75rem 1rem; /* Smaller padding */
-  }
-
-  /* Ensure content doesn't get cut off at the bottom */
-  .footer {
-    margin-top: 1rem;
-    padding-bottom: 1rem;
+/* Fix for iOS Safari viewport issues */
+@supports (-webkit-appearance: none) {
+  .quiz-layout {
+    min-height: -webkit-fill-available; /* Better iOS Safari support */
   }
 }

--- a/src/components/QuizProgress.css
+++ b/src/components/QuizProgress.css
@@ -5,9 +5,9 @@
 
 /* Main container for the entire progress section */
 .quiz-progress {
-  max-width: 500px; /* Limit maximum width */
+  max-width: min(500px, 100% - 1rem); /* Responsive maximum width */
   width: 100%; /* Take full available width up to max-width */
-  margin: 0 auto 1.25rem auto; /* Center horizontally and add space below */
+  margin: 0 auto 1rem auto; /* Center horizontally and add space below */
   padding: 0 0.5rem; /* Add horizontal padding */
   box-sizing: border-box; /* Include padding in width calculation */
 }
@@ -18,6 +18,7 @@
   justify-content: space-between; /* Push items to opposite ends */
   align-items: center; /* Center items vertically */
   margin-bottom: 0.75rem; /* Space below stats section */
+  gap: 1rem; /* Responsive gap between elements */
 }
 
 /* Shared styles for question count and score display boxes */
@@ -29,37 +30,45 @@
     255,
     0.2
   ); /* Semi-transparent white background */
-  padding: 0.6rem 1rem; /* Reduced padding */
+  padding: clamp(0.5rem, 2vw, 0.6rem) clamp(0.75rem, 3vw, 1rem); /* Responsive padding */
   border-radius: 999px; /* Fully rounded corners (pill shape) */
   color: white; /* White text color */
   display: flex; /* Use flexbox layout */
   flex-direction: column; /* Stack label and value vertically */
   align-items: center; /* Center items horizontally */
-  min-width: 110px; /* Reduced minimum width */
+  min-width: clamp(90px, 22vw, 110px); /* Responsive minimum width */
   backdrop-filter: blur(8px); /* Blur effect for modern browsers */
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.25),
     0 1px 2px rgba(0, 0, 0, 0.3);
+  flex: 1; /* Equal width distribution */
+  text-align: center;
 }
 
 /* Style for the label text in stat boxes */
 .question-count span,
 .score-display span {
-  font-size: 0.7rem; /* Smaller font size for labels */
+  font-size: clamp(0.6rem, 1.8vw, 0.7rem); /* Responsive font size for labels */
   opacity: 0.8; /* Slightly transparent for hierarchy */
-  margin-bottom: 0.2rem; /* Reduced space below labels */
+  margin-bottom: clamp(
+    0.125rem,
+    0.5vw,
+    0.2rem
+  ); /* Responsive space below labels */
+  font-weight: 500;
 }
 
 /* Style for the value text in stat boxes */
 .question-count strong,
 .score-display strong {
-  font-size: 1.1rem; /* Smaller font size for values */
+  font-size: clamp(0.9rem, 2.5vw, 1.1rem); /* Responsive font size for values */
   font-weight: 700; /* Bold text */
+  line-height: 1;
 }
 
 /* Container for the progress bar */
 .progress-bar-container {
-  height: 10px; /* Slightly reduced height */
+  height: clamp(8px, 2vw, 10px); /* Responsive progress bar height */
   background-color: rgba(
     255,
     255,
@@ -68,7 +77,11 @@
   ); /* Semi-transparent white background */
   border-radius: 999px; /* Fully rounded corners */
   overflow: hidden; /* Hide overflow for child elements */
-  margin-top: 0.4rem; /* Reduced space above progress bar */
+  margin-top: clamp(
+    0.3rem,
+    1vw,
+    0.4rem
+  ); /* Responsive space above progress bar */
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2); /* Inner shadow for depth */
   position: relative; /* Create positioning context for children */
 }
@@ -116,35 +129,40 @@
 /* Mobile-specific adjustments */
 @media (max-width: 480px) {
   .quiz-progress {
-    margin-bottom: 1rem; /* Further reduced margin */
-    padding: 0 0.5rem; /* Smaller padding */
-    max-width: calc(100% - 1rem); /* Account for padding */
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-bottom: 0.875rem; /* Reduced margin on mobile */
+    padding: 0 0.25rem; /* Smaller padding */
+    max-width: 100%;
   }
 
   .quiz-stats {
     margin-bottom: 0.5rem; /* Smaller margin */
+    gap: 0.75rem; /* Reduced gap */
   }
 
   .question-count,
   .score-display {
-    padding: 0.5rem 0.75rem; /* Smaller padding */
-    min-width: 90px; /* Even smaller width */
-  }
-
-  .question-count span,
-  .score-display span {
-    font-size: 0.65rem; /* Smaller font */
-  }
-
-  .question-count strong,
-  .score-display strong {
-    font-size: 1rem; /* Smaller font */
+    padding: 0.4rem 0.6rem; /* Smaller padding */
+    min-width: 80px; /* Smaller minimum width */
   }
 
   .progress-bar-container {
-    height: 8px; /* Smaller height */
-    margin-top: 0.3rem; /* Smaller margin */
+    height: 7px; /* Smaller progress bar height */
+    margin-top: 0.25rem; /* Smaller margin */
+  }
+}
+
+/* Landscape mobile adjustments */
+@media (max-height: 600px) and (orientation: landscape) {
+  .quiz-progress {
+    margin-bottom: 0.75rem; /* Reduced margin in landscape */
+  }
+
+  .quiz-stats {
+    margin-bottom: 0.4rem; /* Smaller margin in landscape */
+  }
+
+  .question-count,
+  .score-display {
+    padding: 0.35rem 0.7rem; /* Reduced padding in landscape */
   }
 }

--- a/src/components/QuizUserInfo.css
+++ b/src/components/QuizUserInfo.css
@@ -1,52 +1,50 @@
 /* QuizUserInfo.css */
 
 .quiz-user {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.25rem;
-    margin-bottom: 1rem;
-    font-size: 1rem;
-    font-weight: 500;
-    color: white;
-    opacity: 0.9;
-    position: relative;
-    /* ✅ Needed for absolute modal */
-    box-shadow:
-        0 4px 6px rgba(0, 0, 0, 0.3),
-        0 10px 20px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: white;
+  opacity: 0.9;
+  position: relative;
+  /* ✅ Needed for absolute modal */
 }
 
 .user-avatar {
-    font-size: 3rem;
-    width: 72px;
-    height: 72px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: 50%;
-    background-color: rgba(255, 255, 255, 0.15);
-    color: white;
-    cursor: pointer;
-    transition:
-        transform 0.2s ease,
-        background-color 0.2s ease,
-        box-shadow 0.2s ease;
-    box-shadow:
-        0 4px 6px rgba(0, 0, 0, 0.3),
-        0 2px 4px rgba(0, 0, 0, 0.2);
+  font-size: 3rem;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: white;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.3),
+    0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .user-avatar:hover {
-    transform: scale(1.05);
-    background-color: rgba(255, 255, 255, 0.25);
-    box-shadow:
-        0 6px 10px rgba(0, 0, 0, 0.35),
-        0 3px 6px rgba(0, 0, 0, 0.25);
+  transform: scale(1.05);
+  background-color: rgba(255, 255, 255, 0.25);
+  box-shadow:
+    0 6px 10px rgba(0, 0, 0, 0.35),
+    0 3px 6px rgba(0, 0, 0, 0.25);
 }
 
 .user-name {
-    font-size: 1rem;
-    font-weight: 500;
-    opacity: 0.9;
+  font-size: 1rem;
+  font-weight: 500;
+  opacity: 0.9;
+  padding-top: 6px;
 }

--- a/src/pages/Quiz.css
+++ b/src/pages/Quiz.css
@@ -9,21 +9,24 @@
   flex-direction: column; /* Stack content vertically */
   align-items: center; /* Center content horizontally */
   width: 100%; /* Take full available width */
-  max-width: 1200px; /* Limit maximum width */
+  max-width: min(1200px, 100% - 1rem); /* Responsive maximum width */
   margin: 0 auto; /* Center horizontally */
-  padding: 1rem 0.5rem; /* Reduced padding */
+  padding: 0.5rem; /* Responsive padding */
   box-sizing: border-box; /* Include padding in width calculation */
+  min-height: 100vh;
+  min-height: 100svh; /* Small viewport height for mobile */
 }
 
 /* Container for the quiz content area */
 .quiz-content {
   width: 100%; /* Take full available width */
-  max-width: 650px; /* Increased maximum width for better layout */
+  max-width: min(650px, 100% - 1rem); /* Responsive maximum width */
   margin: 0.5rem auto 0; /* Reduced top margin */
   display: flex; /* Use flexbox */
   flex-direction: column; /* Stack elements vertically */
   align-items: center; /* Center elements horizontally */
   box-sizing: border-box; /* Include padding in width calculation */
+  flex: 1;
 }
 
 /* Loading spinner container */
@@ -32,16 +35,17 @@
   flex-direction: column; /* Stack items vertically */
   align-items: center; /* Center items horizontally */
   justify-content: center; /* Center items vertically */
-  min-height: 200px; /* Reduced minimum height */
+  min-height: min(200px, 40vh); /* Responsive minimum height */
   color: white; /* White text color */
   width: 100%; /* Take full width */
   padding: 1rem; /* Add padding */
+  text-align: center;
 }
 
 /* Spinning loader animation */
 .spinner {
-  width: 40px; /* Reduced width of spinner */
-  height: 40px; /* Reduced height of spinner */
+  width: min(40px, 10vw); /* Responsive spinner size */
+  height: min(40px, 10vw); /* Responsive spinner size */
   border: 4px solid rgba(255, 255, 255, 0.3); /* Slightly thinner border */
   border-radius: 50%; /* Circle shape */
   border-top-color: white; /* Solid white top border creates spinner effect */
@@ -65,12 +69,12 @@
     0.2
   ); /* Semi-transparent red background */
   border-radius: 1rem; /* Rounded corners */
-  padding: 1.5rem 1rem; /* Reduced padding */
+  padding: clamp(1rem, 3vw, 1.5rem); /* Responsive padding */
   text-align: center; /* Center text */
   color: white; /* White text color */
-  margin: 1.5rem 0; /* Reduced space above and below */
+  margin: 1rem 0; /* Space above and below */
   width: 100%; /* Take full width */
-  max-width: 600px; /* Limit maximum width */
+  max-width: min(600px, 100% - 1rem); /* Responsive maximum width */
   box-sizing: border-box; /* Include padding in width calculation */
   box-shadow:
     0 4px 6px rgba(0, 0, 0, 0.3),
@@ -79,8 +83,9 @@
 
 /* Error message text */
 .error-container p {
-  margin-bottom: 1.25rem; /* Reduced space below text */
-  font-size: 1rem; /* Smaller font size */
+  margin-bottom: 1rem; /* Space below text */
+  font-size: clamp(0.9rem, 2.5vw, 1rem); /* Responsive font size */
+  line-height: 1.5;
 }
 
 /* Retry button for errors */
@@ -88,7 +93,7 @@
   background-color: white; /* White background */
   color: #4f46e5; /* Purple text color */
   border: none; /* No border */
-  padding: 0.75rem 1.25rem; /* Reduced padding */
+  padding: clamp(0.5rem, 2vw, 0.75rem) clamp(1rem, 3vw, 1.25rem); /* Responsive padding */
   border-radius: 9999px; /* Fully rounded corners (pill shape) */
   font-weight: 600; /* Semi-bold text */
   cursor: pointer; /* Hand cursor on hover */
@@ -96,6 +101,9 @@
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.25),
     0 1px 2px rgba(0, 0, 0, 0.3);
+  font-size: clamp(0.85rem, 2.5vw, 1rem); /* Responsive font size */
+  min-height: 44px; /* Touch-friendly minimum height */
+  min-width: clamp(100px, 25vw, 140px); /* Responsive minimum width */
 }
 
 /* Hover effect for retry button */
@@ -103,9 +111,6 @@
   background-color: #4f46e5; /* Purple background on hover */
   color: white; /* White text on hover */
   transform: scale(1.05); /* Slightly grow button on hover */
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 /* Leaderboard toggle button */
@@ -117,18 +122,21 @@
     0.15
   ); /* Semi-transparent white background */
   color: white; /* White text color */
-  padding: 0.6rem 1.25rem; /* Reduced padding */
+  padding: clamp(0.5rem, 2vw, 0.75rem) clamp(1rem, 3vw, 1.25rem); /* Responsive padding */
   border-radius: 9999px; /* Fully rounded corners (pill shape) */
   font-weight: 600; /* Semi-bold text */
   cursor: pointer; /* Hand cursor on hover */
   transition: all 0.2s ease; /* Smooth transitions for hover effects */
-  margin: 1.5rem auto; /* Reduced space above and below, centered horizontally */
+  margin: 1rem auto; /* Space above and below, centered horizontally */
   display: block; /* Block level element */
   width: fit-content; /* Only as wide as needed for content */
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.25),
     0 1px 2px rgba(0, 0, 0, 0.3);
   border: none;
+  font-size: clamp(0.85rem, 2.5vw, 1rem); /* Responsive font size */
+  min-height: 44px; /* Touch-friendly minimum height */
+  min-width: clamp(100px, 25vw, 140px); /* Responsive minimum width */
 }
 
 /* Hover effect for leaderboard toggle button */
@@ -140,9 +148,6 @@
     0.25
   ); /* Slightly more visible background on hover */
   transform: scale(1.05); /* Move up slightly on hover */
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 /* No questions error state */
@@ -154,12 +159,12 @@
     0.1
   ); /* Semi-transparent white background */
   border-radius: 1rem; /* Rounded corners */
-  padding: 1.5rem 1rem; /* Reduced padding */
+  padding: clamp(1rem, 3vw, 1.5rem); /* Responsive padding */
   text-align: center; /* Center text */
   color: white; /* White text color */
-  margin: 1.5rem 0; /* Reduced space above and below */
+  margin: 1rem 0; /* Space above and below */
   width: 100%; /* Take full width */
-  max-width: 600px; /* Limit maximum width */
+  max-width: min(600px, 100% - 1rem); /* Responsive maximum width */
   box-sizing: border-box; /* Include padding in width calculation */
   box-shadow:
     0 4px 6px rgba(0, 0, 0, 0.3),
@@ -168,25 +173,28 @@
 
 /* No questions error message */
 .no-questions p {
-  margin-bottom: 1.25rem; /* Reduced space below text */
-  font-size: 1rem; /* Smaller font size */
+  margin-bottom: 1rem; /* Space below text */
+  font-size: clamp(0.9rem, 2.5vw, 1rem); /* Responsive font size */
+  line-height: 1.5;
 }
 
 /* Cancel quiz button */
 .cancel-quiz-btn {
-  margin: 1.25rem auto 0; /* Reduced margin */
-  padding: 0.6rem 1.25rem; /* Reduced padding */
+  margin: 1rem auto 0; /* Space above button, centered */
+  padding: clamp(0.5rem, 2vw, 0.75rem) clamp(1rem, 3vw, 1.25rem); /* Responsive padding */
   background-color: rgba(239, 68, 68, 0.9); /* More solid red background */
   color: white; /* White text color */
   border: none;
   border-radius: 9999px; /* Fully rounded corners (pill shape) */
   font-weight: 700; /* Bold text */
-  font-size: 0.9rem; /* Smaller text */
+  font-size: clamp(0.85rem, 2.5vw, 1rem); /* Responsive font size */
   cursor: pointer; /* Hand cursor on hover */
   transition: all 0.2s ease; /* Smooth transitions for hover effects */
   display: block; /* Block element for proper centering */
-  max-width: 140px; /* Limit maximum width */
+  max-width: min(140px, 90vw); /* Responsive maximum width */
   text-align: center; /* Center text */
+  min-height: 44px; /* Touch-friendly minimum height */
+  min-width: clamp(100px, 25vw, 140px); /* Responsive minimum width */
   box-shadow:
     0 2px 4px rgba(0, 0, 0, 0.25),
     0 1px 2px rgba(0, 0, 0, 0.3);
@@ -197,9 +205,6 @@
 .cancel-quiz-btn:hover {
   background-color: #ef4444; /* Solid red background on hover */
   transform: scale(1.05); /* Move up slightly on hover */
-  box-shadow:
-    0 4px 8px rgba(0, 0, 0, 0.3),
-    0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 /* Active state for cancel button */
@@ -210,70 +215,79 @@
 
 /* Make the user info section more prominent */
 .quiz-user {
-  margin-bottom: 1rem; /* Reduced space below user info */
-  background-color: rgba(255, 255, 255, 0.1); /* Semi-transparent background */
-  padding: 0.75rem 1.5rem; /* Reduced padding */
+  margin-bottom: 1rem; /* Space below user info */
+  padding: clamp(0.5rem, 2vw, 0.75rem) clamp(1rem, 3vw, 1.5rem); /* Responsive padding */
   border-radius: 1rem; /* Rounded corners */
-  box-shadow:
-    0 4px 6px rgba(0, 0, 0, 0.3),
-    0 10px 20px rgba(0, 0, 0, 0.2); /* Add shadow */
   width: 100%; /* Take full width */
-  max-width: 600px; /* Limit maximum width */
+  max-width: min(600px, 100% - 1rem); /* Responsive maximum width */
   box-sizing: border-box; /* Include padding in width calculation */
 }
 
 /* Improve quiz progress styling */
 .quiz-progress {
   width: 100%; /* Take full width */
-  max-width: 600px; /* Limit maximum width */
-  margin: 0 auto 1rem; /* Reduced bottom margin */
+  max-width: min(600px, 100% - 1rem); /* Responsive maximum width */
+  margin: 0 auto 1rem; /* Bottom margin */
   box-sizing: border-box; /* Include padding in width calculation */
+}
+
+/* Tablet-specific adjustments */
+@media (max-width: 768px) {
+  .quiz-page {
+    padding: 0.75rem; /* Increased padding for tablets */
+  }
+
+  .quiz-content {
+    max-width: 100%;
+  }
 }
 
 /* Mobile-specific adjustments */
 @media (max-width: 480px) {
   .quiz-page {
-    padding: 0.75rem 0.75rem; /* Increased horizontal padding */
+    padding: 0.5rem; /* Smaller padding for mobile */
   }
 
   .quiz-content {
-    padding: 0 0.75rem; /* Increased horizontal padding */
-    max-width: calc(100% - 1.5rem); /* Account for padding */
-  }
-
-  .spinner {
-    width: 36px; /* Even smaller spinner */
-    height: 36px;
+    padding: 0;
+    max-width: 100%;
   }
 
   .error-container,
   .no-questions {
-    padding: 1.25rem 0.75rem; /* Further reduced padding */
-    margin: 1rem 0.5rem; /* Added horizontal margin */
-    max-width: calc(100% - 1rem); /* Account for margins */
-  }
-
-  .leaderboard-toggle-btn {
-    padding: 0.5rem 1rem; /* Smaller padding */
-    font-size: 0.9rem; /* Smaller font */
-    margin: 1.25rem auto; /* Reduced margin */
-  }
-
-  .cancel-quiz-btn {
-    max-width: 130px; /* Slightly narrower */
-    padding: 0.5rem 1rem; /* Smaller padding */
-    font-size: 0.85rem; /* Smaller font */
+    margin: 0.75rem 0; /* Reduced margins on mobile */
+    max-width: 100%;
   }
 
   .quiz-user {
-    padding: 0.5rem 1rem; /* Smaller padding */
-    margin: 0 0.5rem 1rem 0.5rem; /* Added horizontal margins */
-    max-width: calc(100% - 1rem); /* Account for margins */
+    margin: 0 0 1rem 0; /* Remove horizontal margins on mobile */
+    max-width: 100%;
+  }
+}
+
+/* Large screen optimizations */
+@media (min-width: 1024px) {
+  .quiz-page {
+    padding: 1.5rem; /* Increased padding for large screens */
   }
 
-  /* Prevent fixed elements from causing overflow */
-  .footer {
-    position: relative; /* Ensure footer doesn't cause overflow */
-    padding: 0.75rem; /* Reduced padding */
+  .quiz-content {
+    max-width: 750px; /* Larger content area on big screens */
+  }
+}
+
+/* Landscape mobile optimizations */
+@media (max-height: 600px) and (orientation: landscape) {
+  .quiz-page {
+    padding: 0.25rem; /* Minimal padding in landscape */
+  }
+
+  .loading-container {
+    min-height: 150px; /* Reduced height in landscape */
+  }
+
+  .error-container,
+  .no-questions {
+    padding: 0.75rem 1rem; /* Reduced padding in landscape */
   }
 }


### PR DESCRIPTION
- Implement clamp() for responsive font sizes, padding, and margins
- Add support for small viewport height (100svh) for better mobile experience
- Improve touch targets with minimum 44px height for buttons
- Add responsive width constraints using min() function
- Enable better text breaking with hyphens: auto
- Add landscape orientation optimizations
- Enhance mobile-specific media queries across all quiz components

Closes #60