### PR TITLE
style: mirror quiz-setup styles in Leaderboard for consistent width

### DIFF
--- a/src/components/Leaderboard.css
+++ b/src/components/Leaderboard.css
@@ -1,17 +1,22 @@
 /* ------------------------------------
    Leaderboard
 ------------------------------------ */
+/* src/components/Leaderboard.css */
+
+/* Make leaderboard container mirror .quiz-setup styles */
 .leaderboard {
-  max-width: 500px;
-  margin: 2rem auto 0 auto;
-  padding: 1.5rem;
-  margin-top: 4rem;
-  background: rgba(255, 255, 255, 0.08);
+  background-color: rgba(255, 255, 255, 0.1);
   border-radius: 1rem;
+  padding: 2rem;
+  margin: 0 auto 2rem auto;
+  max-width: 500px;
+  width: 100%;
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.3),
+    0 10px 20px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
   color: white;
   text-align: center;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-  align-self: center;
 }
 
 .leaderboard h2 {


### PR DESCRIPTION
This PR updates the Leaderboard container’s CSS so that it uses the same width, padding, background, and box-shadow settings as the Quiz Setup component.  
- Replaces existing .leaderboard rules with styles matching .quiz-setup  
- Ensures both components share max-width, full-width behavior, padding, and visual treatment for a consistent UI  

No functional changes—purely styling cleanup for better layout alignment.